### PR TITLE
FEAT: Add support for mounting local models directory

### DIFF
--- a/docker-small-team-setup/.env.example
+++ b/docker-small-team-setup/.env.example
@@ -5,6 +5,7 @@ OPENWEBUI_PORT=3000
 
 # Ollama Configuration
 OLLAMA_BASE_URL=http://ollama-container:11434
+# LOCAL_DOWNLOADED_MODELS_MOUNTED=${HOME}/.ollama # Comment it in, if you want sharing mdoels with native Ollama installation
 # OLLAMA_BASE_URLS=http://ollama-container-1:11434;http://ollama-container-2:11434
 
 # Authentication & User Management

--- a/docker-small-team-setup/docker-compose.cpu.yml
+++ b/docker-small-team-setup/docker-compose.cpu.yml
@@ -31,11 +31,22 @@ services:
     container_name: ollama-container
     env_file:
       - .env.gpu-auto
+    environment:
+      - MOUNT_TYPE=${LOCAL_DOWNLOADED_MODELS_MOUNTED:+bind_mount}  # Enters "bind_mount" if has variable. Otherwise, empty.
     depends_on:
       env-setup:
         condition: service_completed_successfully
     volumes:
-      - ollama_data:/root/.ollama
+      - "${LOCAL_DOWNLOADED_MODELS_MOUNTED:-ollama_data}:/root/.ollama"
+    entrypoint: >
+      sh -c "
+      if [ -z \"$$MOUNT_TYPE\" ]; then
+        echo '⚠️  WARNING: Using named volume (ollama_data). Set LOCAL_DOWNLOADED_MODELS_MOUNTED in .env for bind mount.'
+      else
+        echo '✅ Using bind mount from host'
+      fi &&
+      exec /bin/ollama serve
+      "
     restart: unless-stopped
     networks:
       - ollama-network

--- a/docker-small-team-setup/docker-compose.gpu.yml
+++ b/docker-small-team-setup/docker-compose.gpu.yml
@@ -31,11 +31,22 @@ services:
     container_name: ollama-container
     env_file:
       - .env.gpu-auto
+    environment:
+      - MOUNT_TYPE=${LOCAL_DOWNLOADED_MODELS_MOUNTED:+bind_mount}  # Enters "bind_mount" if has variable. Otherwise, empty.
     depends_on:
       env-setup:
         condition: service_completed_successfully
     volumes:
-      - ollama_data:/root/.ollama
+      - "${LOCAL_DOWNLOADED_MODELS_MOUNTED:-ollama_data}:/root/.ollama"
+    entrypoint: >
+      sh -c "
+      if [ -z \"$$MOUNT_TYPE\" ]; then
+        echo '⚠️  WARNING: Using named volume (ollama_data). Set LOCAL_DOWNLOADED_MODELS_MOUNTED in .env for bind mount.'
+      else
+        echo '✅ Using bind mount from host'
+      fi &&
+      exec /bin/ollama serve
+      "
     restart: unless-stopped
     networks:
       - ollama-network


### PR DESCRIPTION
## Changes

- Add LOCAL_DOWNLOADED_MODELS_MOUNTED env var to enable bind mount
- Fallback to ollama_data named volume when env var is not set
- Add startup warning message when using named volume (indicates missing configuration)
- Add startup confirmation when using bind mount

## Configuration

Users can add to `.env`:
```env
LOCAL_DOWNLOADED_MODELS_MOUNTED=C:/Users/username/.ollama
```

If unset, service falls back to `ollama_data` named volume with warning in logs.
